### PR TITLE
fix: MaterializedView.schema() now works on streams

### DIFF
--- a/python/laminardb/types.py
+++ b/python/laminardb/types.py
@@ -251,7 +251,13 @@ class MaterializedView:
 
     def schema(self) -> Schema:
         """Get the schema of this materialized view."""
-        arrow_schema = self._conn.schema(self._name)
+        try:
+            arrow_schema = self._conn.schema(self._name)
+        except Exception:
+            # conn.schema() uses DataFusion catalog which may not contain
+            # streams.  Fall back to querying the stream for its schema.
+            result = self._conn.sql(f"SELECT * FROM {self._name} LIMIT 0")
+            arrow_schema = result.schema
         return Schema(arrow_schema)
 
     def subscribe(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -261,3 +261,26 @@ class TestMaterializedView:
         assert isinstance(schema, Schema)
         assert "id" in schema.names
         conn.close()
+
+    @requires_pyarrow
+    def test_schema_on_stream(self, tmp_path):
+        """mv.schema() should work on streams, not just tables."""
+        conn = laminardb.open(str(tmp_path / "mv_stream_schema.db"))
+        conn.execute(
+            "CREATE SOURCE sensors ("
+            "  ts BIGINT NOT NULL,"
+            "  device VARCHAR NOT NULL,"
+            "  value DOUBLE NOT NULL"
+            ")"
+        )
+        conn.execute(
+            "CREATE STREAM high_val AS "
+            "SELECT * FROM sensors WHERE value > 100.0"
+        )
+        conn.execute("CREATE SINK out FROM high_val")
+        conn.start()
+        mv = MaterializedView(conn, "high_val")
+        schema = mv.schema()
+        assert isinstance(schema, Schema)
+        assert "device" in schema.names
+        conn.close()


### PR DESCRIPTION
## Summary

- Fix `MaterializedView.schema()` to work on streams, not just tables
- Add regression test for `mv.schema()` on a streaming pipeline

## Problem

`MaterializedView.schema()` calls `conn.schema(name)` ([types.py:254](python/laminardb/types.py#L254)) which uses the DataFusion catalog. Streams created via `CREATE STREAM ... AS SELECT` are **not registered** in the DataFusion catalog, so `mv.schema()` raises:

```
laminardb.SchemaError: Table not found (200): Table not found: high_temp
```

This only affects streams — tables created via `create_table()` work fine.

## Fix

Fall back to querying the stream when `conn.schema()` fails:

```python
def schema(self) -> Schema:
    try:
        arrow_schema = self._conn.schema(self._name)
    except Exception:
        result = self._conn.sql(f"SELECT * FROM {self._name} LIMIT 0")
        arrow_schema = result.schema
    return Schema(arrow_schema)
```

This works because `conn.sql("SELECT * FROM stream_name")` correctly queries streams via DataFusion, and `LIMIT 0` avoids fetching actual data.

## Test plan

- [x] Add `test_schema_on_stream` — creates a source + stream pipeline and verifies `mv.schema()` returns expected columns
- [ ] Existing `test_schema` still passes (table-based path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)