### PR TITLE
bump to 0.17.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laminardb"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "laminardb"
-version = "0.15.1"
+version = "0.17.0"
 description = "Python bindings for LaminarDB streaming SQL database"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump crate version in `Cargo.toml` from 0.16.0 to 0.17.0
- Bump Python package version in `pyproject.toml` from 0.15.1 to 0.17.0
- Aligns with the main laminardb workspace version